### PR TITLE
Soycode fixstorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "e2e": "^0.0.5",
-    "es6-promise": "^2.2.0",
+    "es6-promise": "^2.3.0",
     "freedom": "^0.6.25",
     "freedom-for-chrome": "^0.4.19",
     "freedom-for-node": "^0.2.17",
@@ -28,7 +28,7 @@
     "grunt-prompt": "^1.3.0",
     "karma": "^0.12.36",
     "karma-chrome-launcher": "^0.1.12",
-    "karma-coverage": "^0.3.1",
+    "karma-coverage": "^0.4.2",
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.0",

--- a/src/demo/e2edemo.js
+++ b/src/demo/e2edemo.js
@@ -15,6 +15,7 @@ e2edemo.prototype.runCryptoDemo = function() {
   byteView.set([49, 50, 51, 52, 49, 50, 51, 52, 49, 50, 51, 52]);
 
   this.dispatch('print', 'Starting encryption test!');
+  Promise.resolve(e2e.clear());  // clear any existing private key
   e2e.setup('secret passphrase', 'Joe Test <joetest@example.com>').then(
     function () {
       this.dispatch('print', 'Exporting public key...');
@@ -63,8 +64,10 @@ e2edemo.prototype.runImportDemo = function(publicKeyStr, privateKeyStr) {
         }
       }.bind(this)).catch(
         function (e) {
-          this.dispatch('print', 'Keypair import test encountered error %1',
-                        [e]);
+          if (e.message) {
+            e = e.message;
+          }
+          this.dispatch('print', 'Keypair import test encountered error ' + e);
         }.bind(this));
 };
 

--- a/src/e2e.js
+++ b/src/e2e.js
@@ -15,6 +15,7 @@ var mye2e = function(dispatchEvents) {
   this.pgpContext = new e2e.openpgp.ContextImpl();
   this.pgpContext.armorOutput = false;
   this.pgpUser = null;
+  this.storage = new store();
 };
 
 
@@ -41,7 +42,9 @@ mye2e.prototype.clear = function() {
   // Attempting to set another will result in an HMAC error
   // So, make sure to clear before doing so
   // See googstorage.js for details on how storage works
-  store.prototype.clear();
+  if (this.storage.get('UserKeyRing')) {
+    this.storage.remove('UserKeyRing');
+  }
 };
 
 mye2e.prototype.importKeypair = function(passphrase, userid, privateKey) {

--- a/src/e2e.js
+++ b/src/e2e.js
@@ -36,12 +36,21 @@ mye2e.prototype.setup = function(passphrase, userid) {
   return Promise.resolve();
 };
 
+mye2e.prototype.clear = function() {
+  // e2e can only store one private key in LocalStorage
+  // Attempting to set another will result in an HMAC error
+  // So, make sure to clear before doing so
+  // See googstorage.js for details on how storage works
+  store.prototype.clear();
+};
+
 mye2e.prototype.importKeypair = function(passphrase, userid, privateKey) {
+  this.clear();
   this.pgpContext.setKeyRingPassphrase(passphrase);
   this.importKey(privateKey, passphrase);
 
   if (e2e.async.Result.getValue(
-        this.pgpContext.searchPrivateKey(userid)).length === 0 ||
+    this.pgpContext.searchPrivateKey(userid)).length === 0 ||
       e2e.async.Result.getValue(
         this.pgpContext.searchPublicKey(userid)).length === 0) {
     return Promise.reject(Error('Keypair does not match provided userid'));

--- a/src/googstorage.js
+++ b/src/googstorage.js
@@ -68,18 +68,13 @@ store.prototype.deserialize = function(value) {
 
 
 store.prototype.initialize = function() {
-  this.memStorage = store.preparedMem;
-};
-
-store.preparedMem = {};
-
-store.prepareFreedom = function() {
-  freedomStorage = freedom['core.storage']();
-  return freedomStorage.get('UserKeyRing').then(function(value) {
+  store.preparedMem = {};
+  this.freedomStorage.get('UserKeyRing').then(function(value) {
     if (value) {
       store.preparedMem.UserKeyRing = value;
     }
   });
+  this.memStorage = store.preparedMem;
 };
 
 goog.storage.mechanism.HTML5LocalStorage = store;

--- a/src/googstorage.js
+++ b/src/googstorage.js
@@ -2,7 +2,11 @@
 function store () {
   this.freedomStorage = freedom['core.storage']();
   this.memStorage = {};
-  this.initialize();
+  this.freedomStorage.get('UserKeyRing').then(function(value) {
+    if (value) {
+      this.memStorage.UserKeyRing = value;
+    }
+  });
 }
 
 store.prototype.set = function(key, val) {
@@ -27,7 +31,9 @@ store.prototype.remove = function(key) {
 
 store.prototype.clear = function() {
   this.memStorage = {};
-  this.freedomStorage.clear();
+  if (this.freedomStorage) {
+    this.freedomStorage.clear();
+  }
 };
 
 store.prototype.transact = function(key, defaultVal, transactionFn) {
@@ -64,17 +70,6 @@ store.prototype.deserialize = function(value) {
   } catch(e) {
     return value || undefined;
   }
-};
-
-
-store.prototype.initialize = function() {
-  store.preparedMem = {};
-  this.freedomStorage.get('UserKeyRing').then(function(value) {
-    if (value) {
-      store.preparedMem.UserKeyRing = value;
-    }
-  });
-  this.memStorage = store.preparedMem;
 };
 
 goog.storage.mechanism.HTML5LocalStorage = store;

--- a/src/pgpapi.json
+++ b/src/pgpapi.json
@@ -4,7 +4,7 @@
   "app": {
     "script": [
       "end-to-end.compiled.js",
-      "googstorage_mock.js",
+      "googstorage.js",
       "e2e.js"
     ]
   },

--- a/src/pgpapi.json
+++ b/src/pgpapi.json
@@ -36,8 +36,16 @@
         "err": { "errcode": "string", "message": "string" }
       },
 
+      "clear": {
+        "_comment": "Clear local storage, resetting priavte key",
+        "type": "method",
+        "value": [],
+        "ret": [],
+        "err": { "errcode": "string", "message": "string" }
+      },
+
       "importKeypair": {
-        "_comment": "Import a pre-existing public/private keypair",
+        "_comment": "Import a public/private keypair, overwriting if needed",
         "type": "method",
         "value": ["string", "string", "string"],
         "ret": [],

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -24,6 +24,7 @@
 
     var start = function(PGP) {
     var crypt = window.crypter = new PGP();
+    Promise.resolve(crypt.clear());  // clear local storage to reset key
     var input = document.getElementById('input');
     var key = document.getElementById('key');
     var output = document.getElementById('output');

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -39,6 +39,8 @@
       output.innerHTML = "<font color='green'>Success</font><br />";
       if (typeof val === 'string') {
         output.innerHTML += val;
+      } else if (val.key) {
+        output.innerHTML += val.key + '\n\n' + val.fingerprint;
       }
     }
     var decryptSuccess = function(result) {


### PR DESCRIPTION
With this pull request, keys should correctly persist across sessions, assuming you use the same user id and passphrase. If you try to use an incorrect user id/passphrase with a persisted key you'll receive an "HMAC does not match" error - if this is because you want to use a different key, then you need to use the new .clear() method to reset local storage as e2e purposely only supports a single keyring (https://github.com/google/end-to-end/issues/223).

Status - tests still pass, and initial plausibility is good. Haven't tried it end-to-end in a proper dependent application yet (I made the tests/demo reset the key for each run as that is more sensible for their use case). So, some tweaks may still be needed, but I believe this is a solid step in the right direction.