### PR TITLE
Soycode firefoxcorecrypto

### DIFF
--- a/src/e2e.js
+++ b/src/e2e.js
@@ -6,29 +6,23 @@ if (typeof Promise === 'undefined' && typeof ES6Promise !== 'undefined') {
   Promise = ES6Promise.Promise;
 }
 
+// getRandomValue polyfill for Firefox - remove when FF webworkers implement
 var refreshBuffer = function (size) { return Promise.resolve(); };  // null-op
 if (typeof crypto === 'undefined') {
-  console.log("POLYFILLING CRYPTO RANDOM");
   var rand = freedom['core.crypto'](),
       buf,
       offset = 0;
   refreshBuffer = function (size) {
-    console.log('in rb');
     return rand.getRandomBytes(size).then(function (bytes) {
-      console.log('done refresh');
       buf = new Uint8Array(bytes);
       offset = 0;
-      //return Promise.resolve();
     }, function (err) {
-      console.log('err!');
       console.log(err);
-      //return Promise.resolve();
     });
   }.bind(this);
 
   crypto = {};
   crypto.getRandomValues = function (buffer) {
-    console.log('trying to get randomness');
     if (buffer.buffer) {
       buffer = buffer.buffer;
     }
@@ -43,7 +37,7 @@ if (typeof crypto === 'undefined') {
     }
     offset += size;
   };
-  }
+}
 
 /**
  * Implementation of a crypto-pgp provider for freedom.js
@@ -65,7 +59,7 @@ mye2e.prototype.setup = function(passphrase, userid) {
   }
   this.pgpUser = userid;
   var scope = this;  // jasmine tests fail w/bind approach
-  return refreshBuffer(50000).then(store.prepareFreedom).then(function() {
+  return refreshBuffer(5000).then(store.prepareFreedom).then(function() {
     scope.pgpContext.setKeyRingPassphrase(passphrase);
     if (e2e.async.Result.getValue(
       scope.pgpContext.searchPrivateKey(scope.pgpUser)).length === 0) {
@@ -117,6 +111,7 @@ mye2e.prototype.exportKey = function() {
 };
 
 mye2e.prototype.signEncrypt = function(data, encryptKey, sign) {
+  Promise.resolve(refreshBuffer(5000));
   if (typeof sign === 'undefined') {
     sign = true;
   }

--- a/src/e2e.js
+++ b/src/e2e.js
@@ -6,6 +6,17 @@ if (typeof Promise === 'undefined' && typeof ES6Promise !== 'undefined') {
   Promise = ES6Promise.Promise;
 }
 
+if (typeof crypto === 'undefined') {
+  console.log("POLYFILLING CRYPTO RANDOM");
+  var rand = freedom['core.crypto']();
+  crypto = {};
+  crypto.getRandomValues = function (array) {
+    rand.getRandomBytes(array.byteLength).then(function (bytes) {
+      array = array.constructor(bytes);
+    });
+  };
+}
+
 /**
  * Implementation of a crypto-pgp provider for freedom.js
  * using cryptographic code from Google's end-to-end.

--- a/src/e2e.js
+++ b/src/e2e.js
@@ -6,23 +6,23 @@ if (typeof Promise === 'undefined' && typeof ES6Promise !== 'undefined') {
   Promise = ES6Promise.Promise;
 }
 
-var refreshBuffer = function (size, callback) { };  // null-op
+var refreshBuffer = function (size) { return Promise.resolve(); };  // null-op
 if (typeof crypto === 'undefined') {
   console.log("POLYFILLING CRYPTO RANDOM");
   var rand = freedom['core.crypto'](),
       buf,
       offset = 0;
-  refreshBuffer = function (size, callback) {
+  refreshBuffer = function (size) {
     console.log('in rb');
-    rand.getRandomBytes(size).then(function (bytes) {
+    return rand.getRandomBytes(size).then(function (bytes) {
       console.log('done refresh');
       buf = new Uint8Array(bytes);
       offset = 0;
-      return Promise.resolve(callback(0));
+      //return Promise.resolve();
     }, function (err) {
       console.log('err!');
       console.log(err);
-      return Promise.resolve(callback(-1, err));
+      //return Promise.resolve();
     });
   }.bind(this);
 

--- a/src/pgpapi.json
+++ b/src/pgpapi.json
@@ -95,6 +95,7 @@
   },
 
   "permissions": [
+    "core.crypto",
     "core.storage"
   ]
 }


### PR DESCRIPTION
Fixes #36, aspirationally at least. Buffering is naive and ad hoc right now (5000 bytes before setup and signEncrypt calls, which I believe are the two calls that need randomness), and in my testing it has the curious behavior of working *every other time* - that is, `grunt demo` and refreshing the demo page in Firefox will alternate between hanging on the setup and running the whole demo successfully.

So, this isn't really ready for review just yet and I do intend to keep investigating myself and will flag people when it's more ready. Still, thoughts/feedback/insight welcome.