### PR TITLE
Fix bugs related to name collision and state refresh

### DIFF
--- a/spec/e2e.spec.js
+++ b/spec/e2e.spec.js
@@ -79,8 +79,9 @@ describe('e2eImp', function () {
   it('test importKey and deleteKey with public key', function(done) {
     e2eImp.setup('test passphrase', 'Test User <test@example.com>').then(
       function () {
-        return e2eImp.importKey(publicKeyStr);
-      }).then(function () {
+        return e2eImp.importPubKey(publicKeyStr);
+      }).then(function (keyObj) {
+        expect(keyObj.key.fingerprintHex).toEqual(keyFingerprint);
         return e2eImp.searchPublicKey('<quantsword@gmail.com>');
       }).then(function (keys) {
         expect(keys.length).toEqual(1);
@@ -113,7 +114,7 @@ describe('e2eImp', function () {
   it('test importKey and deleteKey with private key', function(done) {
     e2eImp.setup('test passphrase', 'Test User <testuser@gmail.com>').then(
       function () {
-        return e2eImp.importKey(privateKeyStr);
+        return e2eImp.importPrivKey(privateKeyStr);
       }).then(function () {
         return e2eImp.searchPrivateKey('<quantsword@gmail.com>');
       }).then(function (keys) {

--- a/spec/e2e.spec.js
+++ b/spec/e2e.spec.js
@@ -254,7 +254,7 @@ describe('e2eImp', function () {
         return otherUser;
       });
     }).then(
-      function (otherUser) {
+      function(otherUser) {
         return Promise.all([otherUser.exportKey(),
             otherUser.signEncrypt(buffer)]);
       }).then(function (array) {
@@ -263,6 +263,104 @@ describe('e2eImp', function () {
         return e2eImp.verifyDecrypt(signedData, key);
       }).then(function (result) {
         expect(result.data).toEqual(buffer);
+      }).catch(function (e) {
+        console.log(e.toString());
+        expect(false).toBeTruthy();
+      }).then(done);
+  });
+
+  it('getFingerprint of users with the same name', function(done) {
+    var otherUser0 = new mye2e();
+    var otherUser1 = new mye2e();
+    e2eImp.setup('test passphrase', 'Test User <test@example.com>').then(
+        function () {
+      return Promise.all([
+        otherUser0.setup('test passphrase', 'Test User <test@example.com>'),
+        otherUser1.setup('test passphrase', 'Test User <test@example.com>')
+      ]);
+    }).then(function () {
+        return Promise.all([otherUser0.exportKey(), otherUser1.exportKey()]);
+      }).then(function (keys) {
+        // Check that the test is functioning correctly, generating new keys.
+        expect(keys[0].key).not.toEqual(keys[1].key);
+        expect(keys[0].fingerprint).not.toEqual(keys[1].fingerprint);
+
+        // Check that the fingerprints are computed correctly
+        return Promise.all([
+          e2eImp.getFingerprint(keys[0].key).then(function(fp) {
+            expect(fp.fingerprint).toEqual(keys[0].fingerprint);
+          }),
+          e2eImp.getFingerprint(keys[1].key).then(function(fp) {
+            expect(fp.fingerprint).toEqual(keys[1].fingerprint);
+          })
+        ]);
+      }).catch(function (e) {
+        console.log(e.toString());
+        expect(false).toBeTruthy();
+      }).then(done);
+  });
+
+  it('verify messages from users with the same name', function(done) {
+    var otherUser0 = new mye2e();
+    var otherUser1 = new mye2e();
+    e2eImp.setup('test passphrase', 'Test User <test@example.com>').then(function() {
+      return Promise.all([
+        otherUser0.setup('test passphrase', 'Test User <test@example.com>'),
+        otherUser1.setup('test passphrase', 'Test User <test@example.com>')
+      ]);
+    }).then(function () {
+        // Sign a message from user0, and verify with e2eImp
+        return Promise.all([otherUser0.exportKey(),
+            otherUser0.signEncrypt(buffer)]);
+      }).then(function (array) {
+        var key = array[0].key;
+        var signedData = array[1];
+        return e2eImp.verifyDecrypt(signedData, key);
+      }).then(function (result) {
+        expect(result.data).toEqual(buffer);
+
+        // Sign a message from user1, and verify with e2eImp
+        return Promise.all([otherUser1.exportKey(),
+            otherUser1.signEncrypt(buffer)]);
+      }).then(function (array) {
+        var key = array[0].key;
+        var signedData = array[1];
+        return e2eImp.verifyDecrypt(signedData, key);
+      }).then(function (result) {
+        expect(result.data).toEqual(buffer);
+      }).catch(function (e) {
+        console.log(e.toString());
+        expect(false).toBeTruthy();
+      }).then(done);
+  });
+
+  it('encrypt messages to users with the same name', function(done) {
+    var otherUser0 = new mye2e();
+    var otherUser1 = new mye2e();
+    e2eImp.setup('test passphrase', 'Test User <test@example.com>').then(function() {
+      return Promise.all([
+        otherUser0.setup('test passphrase', 'Test User <test@example.com>'),
+        otherUser1.setup('test passphrase', 'Test User <test@example.com>')
+      ]);
+    }).then(function () {
+        return Promise.all([otherUser0.exportKey(), otherUser1.exportKey()]);
+      }).then(function (keys) {
+        // Check that the test is functioning correctly, generating new keys.
+        expect(keys[0].key).not.toEqual(keys[1].key);
+
+        // Encrypt a message to both users
+        return Promise.all([
+          e2eImp.signEncrypt(buffer, keys[0].key),
+          e2eImp.signEncrypt(buffer, keys[1].key)
+        ]);
+      }).then(function (cipherTexts) {
+        return Promise.all([
+          otherUser0.verifyDecrypt(cipherTexts[0]),
+          otherUser1.verifyDecrypt(cipherTexts[1])
+        ]);
+      }).then(function (results) {
+        expect(results[0].data).toEqual(buffer);
+        expect(results[1].data).toEqual(buffer);
       }).catch(function (e) {
         console.log(e.toString());
         expect(false).toBeTruthy();

--- a/src/googstorage.js
+++ b/src/googstorage.js
@@ -67,10 +67,14 @@ store.prototype.deserialize = function(value) {
 };
 
 store.prototype.initialize = function() {
+  if (!store.isPrepared) {
+    throw new Error('store is not yet prepared');
+  }
   this.memStorage = store.preparedMem;
 };
 
 store.preparedMem = {};
+store.isPrepared = false;
 
 // IMPORTANT - this function must be called and resolved before instantiating
 // a store object, otherwise async nastiness w/freedom localStorage occurs
@@ -79,6 +83,7 @@ store.prepareFreedom = function() {
     if (value) {
       store.preparedMem.UserKeyRing = value;
     }
+    store.isPrepared = true;
   });
 };
 

--- a/src/googstorage_mock.js
+++ b/src/googstorage_mock.js
@@ -1,5 +1,8 @@
 function store () {
   this.storage = {};
+  if (!store.isPrepared) {
+    throw new Error('store not yet prepared');
+  }
 }
 
 store.prototype.set = function(key, val) {
@@ -50,8 +53,11 @@ store.prototype.deserialize = function(value) {
   catch(e) { return value || undefined; }
 };
 
+store.isPrepared = false;
+
 store.prepareFreedom = function() {
   // mock doesn't actually use freedom localStorage
+  store.isPrepared = true;
   return Promise.resolve();
 };
 


### PR DESCRIPTION
There were bugs related to
 * getting the fingerprint of a key, if another key is known with the same userId
 * encrypting a message to a key, if another key is known with the same userId
 * losing state on refresh, because the local storage shim was instantiated before being prepared

This change fixes these bugs, and adds regression tests for them.